### PR TITLE
Fixes: CMake + QBS improvements

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -10,6 +10,7 @@ file(GLOB ${PROJECT_NAME}_srcFiles
     "src/systems/*.cpp"
     "src/filters/*.cpp"
     "src/pipelinetasks/*.cpp"
+    "src/utils/*.cpp"
 )
 
 set(${PROJECT_NAME}_incPaths
@@ -20,14 +21,15 @@ set(${PROJECT_NAME}_incPaths
     "../thirdparty/next/inc/anim"
     "../thirdparty/physfs/src"
     "../thirdparty/glfw/include"
+    "../thirdparty/glfw/src"
     "../thirdparty/glfm/include"
     "../thirdparty/freetype/include"
     "../thirdparty/assimp/include"
-    "../modules/uikit/includes"
     "includes/components"
     "includes/resources"
     "includes/adapters"
     "includes/editor"
+    "includes/utils"
     "includes"
 )
 
@@ -106,7 +108,6 @@ if (desktop)
     file(GLOB ${PROJECT_NAME}_headers
         "includes/*.h"
         "includes/components/*.h"
-        "includes/components/gui/*.h"
         "includes/resources/*.h"
         "includes/pipelinetasks/*.h"
     )

--- a/engine/engine.qbs
+++ b/engine/engine.qbs
@@ -24,7 +24,6 @@ Project {
         "../thirdparty/freetype/include",
         "../thirdparty/assimp/include",
         "includes/components",
-        "includes/components/gui",
         "includes/resources",
         "includes/adapters",
         "includes/editor",

--- a/modules/editor/grapheditor/CMakeLists.txt
+++ b/modules/editor/grapheditor/CMakeLists.txt
@@ -48,6 +48,7 @@ if (desktop)
     target_link_libraries(${PROJECT_NAME}-editor PRIVATE
         next-editor
         engine-editor
+        uikit-editor
         Qt5::Core
         Qt5::Gui
         Qt5::Widgets

--- a/modules/uikit/CMakeLists.txt
+++ b/modules/uikit/CMakeLists.txt
@@ -5,6 +5,7 @@ project(uikit)
 file(GLOB ${PROJECT_NAME}_srcFiles
     "src/*.cpp"
     "src/components/*.cpp"
+    "src/editor/*.cpp"
 	"src/pipelinetasks/*.cpp"
     "src/resources/*.cpp"
 	"src/utils/*.cpp"
@@ -12,6 +13,7 @@ file(GLOB ${PROJECT_NAME}_srcFiles
 
 set(${PROJECT_NAME}_incPaths
     "includes"
+    "includes/resources"
     "../../common"
     "../../engine/includes"
     "../../engine/includes/resources"
@@ -49,6 +51,11 @@ set( RESOURCES
 QT5_ADD_RESOURCES(RES_SOURCES ${RESOURCES})
 QT5_WRAP_UI(UI_HEADERS ${${PROJECT_NAME}_ui})
 QT5_WRAP_CPP(MOC_SRCS ${MOC_HEADERS})
+
+add_definitions (
+    -DCOMPANY_NAME="${COMPANY_NAME}"
+    -DEDITOR_NAME="${EDITOR_NAME}"
+)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${${PROJECT_NAME}_srcFiles})
 

--- a/modules/uikit/src/components/label.cpp
+++ b/modules/uikit/src/components/label.cpp
@@ -2,7 +2,7 @@
 
 #include "components/recttransform.h"
 
-#include "resources/stylesheet.h"
+#include "stylesheet.h"
 
 #include <components/actor.h>
 #include <components/textrender.h>

--- a/modules/uikit/src/components/uiloader.cpp
+++ b/modules/uikit/src/components/uiloader.cpp
@@ -4,7 +4,7 @@
 #include "components/widget.h"
 #include "components/recttransform.h"
 
-#include "resources/stylesheet.h"
+#include "stylesheet.h"
 
 #include "utils/stringutil.h"
 

--- a/modules/uikit/src/components/widget.cpp
+++ b/modules/uikit/src/components/widget.cpp
@@ -3,7 +3,7 @@
 #include "components/recttransform.h"
 #include "components/layout.h"
 
-#include "resources/stylesheet.h"
+#include "stylesheet.h"
 #include "utils/stringutil.h"
 
 #include "uisystem.h"

--- a/thirdparty/LIBRARIES.md
+++ b/thirdparty/LIBRARIES.md
@@ -36,7 +36,7 @@
 ## glfw
 
 - Link: https://github.com/glfw/glfw
-- Version: 3.2
+- Version: 3.4
 - License: Zlib
 
 ## glslang

--- a/thirdparty/glfw/CMakeLists.txt
+++ b/thirdparty/glfw/CMakeLists.txt
@@ -7,11 +7,17 @@ set(srcFiles
     "src/init.c"
     "src/input.c"
     "src/monitor.c"
+    "src/null_init.c"
+    "src/null_joystick.c"
+    "src/null_monitor.c"
+    "src/null_window.c"
+    "src/platform.c"
     "src/vulkan.c"
     "src/window.c"
     "src/osmesa_context.c"
     "src/egl_context.c"
     "src/internal.h"
+    "src/null_platform.h"
     "include/GLFW/glfw3.h"
     "include/GLFW/glfw3native.h"
 )
@@ -20,6 +26,7 @@ if (WIN32)
     set(${PROJECT_NAME}_platform
         "src/win32_init.c"
         "src/win32_joystick.c"
+        "src/win32_module.c"
         "src/win32_monitor.c"
         "src/win32_time.c"
         "src/win32_thread.c"
@@ -27,7 +34,6 @@ if (WIN32)
         "src/wgl_context.c"
         "src/win32_platform.h"
         "src/win32_joystick.h"
-        "src/wgl_context.h"
     ) 
 elseif (APPLE)
     set(${PROJECT_NAME}_platform
@@ -35,12 +41,12 @@ elseif (APPLE)
         "src/cocoa_joystick.m"
         "src/cocoa_monitor.m"
         "src/cocoa_time.c"
+        "src/posix_poll.c"
         "src/posix_thread.c"
         "src/cocoa_window.m"
         "src/nsgl_context.m"
         "src/cocoa_platform.h"
         "src/cocoa_joystick.h"
-        "src/nsgl_context.h"
     ) 
 else ()
     set(${PROJECT_NAME}_platform
@@ -48,6 +54,8 @@ else ()
         "src/linux_joystick.c"
         "src/xkb_unicode.c"
         "src/x11_monitor.c"
+        "src/posix_module.c"
+        "src/posix_poll.c"
         "src/posix_time.c"
         "src/posix_thread.c"
         "src/x11_window.c"


### PR DESCRIPTION
Most of these were minor fixes. Since most of the code in the uikit module used `#include "resources/stylesheet.h"` syntax, I converted uiloader.h to the same but can revert if requested. My port fully builds now and I'm testing it out. Found one issue so far, but I'll need to test further before pushing a fix.