### PR TITLE
Fix: uikit-editor plugin name by platform

### DIFF
--- a/engine/src/editor/pluginmanager.cpp
+++ b/engine/src/editor/pluginmanager.cpp
@@ -147,7 +147,9 @@ void PluginManager::init(Engine *engine) {
 
     syncWhiteList();
 
+#if defined(__WIN32__) || defined(__APPLE__)
     loadPlugin(QCoreApplication::applicationDirPath() + "/uikit-editor" + gShared);
+#endif
     rescanPath(QString(QCoreApplication::applicationDirPath() + PLUGINS));
 }
 


### PR DESCRIPTION
This is a minor fix but the uikit-editor plugin name is different based on platform. Only Mac and Windows use just uikit-editor.

This is also only assuming it's running as an SDK install. When running from an external build directory after building with CMake, it will error out due to the pathing.