### PR TITLE
Fixes: Linux + BSD Build Fixes

### DIFF
--- a/builder/CMakeLists.txt
+++ b/builder/CMakeLists.txt
@@ -65,6 +65,17 @@ if (desktop)
 
     target_include_directories(${BUILDER_NAME} PRIVATE ${${PROJECT_NAME}_incPaths} ${CMAKE_CURRENT_BINARY_DIR})
 
+    if(UNIX AND NOT APPLE)
+        set_target_properties(${BUILDER_NAME} PROPERTIES
+            INSTALL_RPATH "$ORIGIN/../lib"
+        )
+
+        # Solve build error using Clang on BSDs
+        if(NOT LINUX)
+            target_compile_options(${BUILDER_NAME} PRIVATE -fPIC)
+        endif()
+    endif()
+
     set_target_properties(${BUILDER_NAME} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY_DEBUG "../${BIN_PATH}"
         RUNTIME_OUTPUT_DIRECTORY_RELEASE "../${BIN_PATH}"

--- a/modules/editor/grapheditor/CMakeLists.txt
+++ b/modules/editor/grapheditor/CMakeLists.txt
@@ -60,9 +60,15 @@ if (desktop)
         NODEGRAPH_LIBRARY
     )
 
-    # Solve build error using Clang on BSDs
-    if(UNIX AND NOT APPLE AND NOT LINUX)
-        target_compile_options(${PROJECT_NAME}-editor PRIVATE -fPIC)
+    if(UNIX AND NOT APPLE)
+        set_target_properties(${PROJECT_NAME}-editor PROPERTIES
+            INSTALL_RPATH "$ORIGIN/../lib"
+        )
+
+        # Solve build error using Clang on BSDs
+        if (NOT LINUX)
+            target_compile_options(${PROJECT_NAME}-editor PRIVATE -fPIC)
+        endif()
     endif()
 
     target_include_directories(${PROJECT_NAME}-editor PRIVATE ${${PROJECT_NAME}_incPaths} ${CMAKE_CURRENT_BINARY_DIR})

--- a/modules/editor/grapheditor/grapheditor.qbs
+++ b/modules/editor/grapheditor/grapheditor.qbs
@@ -40,6 +40,11 @@ Project {
         cpp.minimumMacosVersion: grapheditor.osxVersion
 
         Properties {
+            condition: qbs.targetOS.contains("linux")
+            cpp.rpaths: "$ORIGIN/../lib"
+        }
+
+        Properties {
             condition: qbs.targetOS.contains("darwin")
             cpp.sonamePrefix: "@executable_path"
         }

--- a/modules/editor/texteditor/CMakeLists.txt
+++ b/modules/editor/texteditor/CMakeLists.txt
@@ -55,9 +55,15 @@ if (desktop)
         SHARED_DEFINE
     )
 
-    # Solve build error using Clang on BSDs
-    if(UNIX AND NOT APPLE AND NOT LINUX)
-        target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
+    if(UNIX AND NOT APPLE)
+        set_target_properties(${PROJECT_NAME} PROPERTIES
+            INSTALL_RPATH "$ORIGIN/../../lib"
+        )
+
+        # Solve build error using Clang on BSDs
+        if(NOT LINUX)
+            target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
+        endif()
     endif()
 
     target_include_directories(${PROJECT_NAME} PRIVATE ${${PROJECT_NAME}_incPaths} ${CMAKE_CURRENT_BINARY_DIR})

--- a/modules/editor/texteditor/texteditor.qbs
+++ b/modules/editor/texteditor/texteditor.qbs
@@ -41,6 +41,11 @@ Project {
         cpp.minimumMacosVersion: texteditor.osxVersion
 
         Properties {
+            condition: qbs.targetOS.contains("linux")
+            cpp.rpaths: "$ORIGIN/../../lib"
+        }
+
+        Properties {
             condition: qbs.targetOS.contains("darwin")
             cpp.sonamePrefix: "@executable_path"
         }

--- a/modules/editor/texturetools/CMakeLists.txt
+++ b/modules/editor/texturetools/CMakeLists.txt
@@ -57,9 +57,15 @@ if (desktop)
         SHARED_DEFINE
     )
 
-    # Solve build error using Clang on BSDs
-    if(UNIX AND NOT APPLE AND NOT LINUX)
-        target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
+    if(UNIX AND NOT APPLE)
+        set_target_properties(${PROJECT_NAME} PROPERTIES
+            INSTALL_RPATH "$ORIGIN/../../lib"
+        )
+
+        # Solve build error using Clang on BSDs
+        if(NOT LINUX)
+            target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
+        endif()
     endif()
 
     target_include_directories(${PROJECT_NAME} PRIVATE ${${PROJECT_NAME}_incPaths} ${CMAKE_CURRENT_BINARY_DIR})

--- a/modules/editor/timeline/CMakeLists.txt
+++ b/modules/editor/timeline/CMakeLists.txt
@@ -74,6 +74,17 @@ if (desktop)
         SHARED_DEFINE
     )
 
+    if(UNIX AND NOT APPLE)
+        set_target_properties(${PROJECT_NAME} PROPERTIES
+            INSTALL_RPATH "$ORIGIN/../../lib"
+        )
+
+        # Solve build error using Clang on BSDs
+        if(NOT LINUX)
+            target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
+        endif()
+    endif()
+
     # Solve build error using Clang on BSDs
     if(UNIX AND NOT APPLE AND NOT LINUX)
         target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)

--- a/modules/editor/timeline/timeline.qbs
+++ b/modules/editor/timeline/timeline.qbs
@@ -49,6 +49,11 @@ Project {
         cpp.minimumMacosVersion: timeline.osxVersion
 
         Properties {
+            condition: qbs.targetOS.contains("linux")
+            cpp.rpaths: "$ORIGIN/../../lib"
+        }
+
+        Properties {
             condition: qbs.targetOS.contains("darwin")
             cpp.sonamePrefix: "@executable_path"
         }

--- a/modules/media/CMakeLists.txt
+++ b/modules/media/CMakeLists.txt
@@ -23,12 +23,21 @@ set(${PROJECT_NAME}_incPaths
     "../../thirdparty/libvorbis/src"
 )
 
-# This path is only needed on the BSDs
-if(UNIX AND NOT APPLE AND NOT LINUX)
+# find where OpenAL is installed on user's system
+if(UNIX AND NOT APPLE)
+    find_package(OpenAL REQUIRED)
     set(${PROJECT_NAME}_incPaths
         ${${PROJECT_NAME}_incPaths}
-        "/usr/local/include"
+        ${OPENAL_INCLUDE_DIR}
     )
+
+    # This path is only needed on the BSDs
+    if(NOT LINUX)
+        set(${PROJECT_NAME}_incPaths
+            ${${PROJECT_NAME}_incPaths}
+            "/usr/local/include"
+        )
+    endif()
 endif()
 
 file(GLOB MOC_HEADERS
@@ -69,6 +78,7 @@ if (desktop)
     )
 
     if(UNIX AND NOT APPLE)
+        target_link_libraries(${PROJECT_NAME}-editor PRIVATE ${OPENAL_LIBRARY})
         set_target_properties(${PROJECT_NAME}-editor PROPERTIES
             INSTALL_RPATH "$ORIGIN/../../lib"
         )
@@ -115,15 +125,20 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     ogg
     vorbis
 )
+
 if (NOT desktop)
     target_compile_definitions(${PROJECT_NAME} PRIVATE
         THUNDER_MOBILE
     )
 endif()
 
-# Solve build error using Clang on BSDs
-if(UNIX AND NOT APPLE AND NOT LINUX)
-    target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME}-editor PRIVATE ${OPENAL_LIBRARY})
+
+    # Solve build error using Clang on BSDs
+    if(NOT LINUX)
+        target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
+    endif()
 endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${${PROJECT_NAME}_incPaths})

--- a/modules/uikit/CMakeLists.txt
+++ b/modules/uikit/CMakeLists.txt
@@ -90,20 +90,26 @@ if (desktop)
         UIKIT_LIBRARY
     )
 
-    # Solve build error using Clang on BSDs
-    if(UNIX AND NOT APPLE AND NOT LINUX)
-        target_compile_options(${PROJECT_NAME}-editor PRIVATE -fPIC)
+    if(UNIX AND NOT APPLE)
+        set_target_properties(${PROJECT_NAME}-editor PROPERTIES
+            INSTALL_RPATH "$ORIGIN/../lib"
+        )
+
+        # Solve build error using Clang on BSDs
+        if(NOT LINUX)
+            target_compile_options(${PROJECT_NAME}-editor PRIVATE -fPIC)
+        endif()
     endif()
 
     target_include_directories(${PROJECT_NAME}-editor PRIVATE ${${PROJECT_NAME}_incPaths} ${CMAKE_CURRENT_BINARY_DIR})
 
     set_target_properties(${PROJECT_NAME}-editor PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY_DEBUG "../../${PLUGINS_PATH}"
-        RUNTIME_OUTPUT_DIRECTORY_RELEASE "../../${PLUGINS_PATH}"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG "../../${LIB_PATH}"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "../../${LIB_PATH}"
     )
 
     install(TARGETS ${PROJECT_NAME}-editor
-            DESTINATION "${PLUGINS_PATH}"
+        DESTINATION "${LIB_PATH}"
     )
 
     install(FILES "includes/${PROJECT_NAME}.h"

--- a/modules/uikit/uikit.qbs
+++ b/modules/uikit/uikit.qbs
@@ -57,6 +57,11 @@ Project {
         cpp.cxxStandardLibrary: uikit.standardLibrary
         cpp.minimumMacosVersion: uikit.osxVersion
 
+        Properties {
+            condition: qbs.targetOS.contains("linux")
+            cpp.rpaths: "$ORIGIN/../lib"
+        }
+
         Group {
             name: "Install Dynamic uikit"
             fileTagsFilter: ["dynamiclibrary", "dynamiclibrary_import"]

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ if (desktop)
 
     if(UNIX AND NOT APPLE)
         set_target_properties(${PROJECT_NAME} PROPERTIES
-            INSTALL_RPATH "$ORIGIN/../../lib"
+            INSTALL_RPATH "$ORIGIN/../lib"
         )
 
         # Solve build error using Clang on BSDs

--- a/thirdparty/libvorbis/CMakeLists.txt
+++ b/thirdparty/libvorbis/CMakeLists.txt
@@ -45,31 +45,44 @@ if(WIN32 AND NOT MINGW)
 endif()
 
 # Dynamic Library
-add_library(${PROJECT_NAME}-editor SHARED ${vorbis_src_files} ${vorbis_def})
-target_include_directories(${PROJECT_NAME}-editor PRIVATE ${${PROJECT_NAME}_incPaths})
-target_compile_definitions(${PROJECT_NAME}-editor PRIVATE LIBVORBIS_LIBRARY)
+if(desktop)
+    add_library(${PROJECT_NAME}-editor SHARED ${vorbis_src_files} ${vorbis_def})
+    target_include_directories(${PROJECT_NAME}-editor PRIVATE ${${PROJECT_NAME}_incPaths})
+    target_compile_definitions(${PROJECT_NAME}-editor PRIVATE LIBVORBIS_LIBRARY)
 
-target_link_libraries(${PROJECT_NAME}-editor PRIVATE
-    ogg-editor
-)
+    target_link_libraries(${PROJECT_NAME}-editor PRIVATE
+        ogg-editor
+    )
 
-if (APPLE)
+    if (APPLE)
+        set_target_properties(${PROJECT_NAME}-editor PROPERTIES
+            INSTALL_NAME_DIR "@executable_path"
+        )
+    endif()
+
+    if(UNIX AND NOT APPLE)
+        set_target_properties(${PROJECT_NAME}-editor PROPERTIES
+            INSTALL_RPATH "$ORIGIN/../lib"
+        )
+
+        # Solve build error using Clang on BSDs
+        if(NOT LINUX)
+            target_compile_options(${PROJECT_NAME}-editor PRIVATE -fPIC)
+        endif()
+    endif()
+
     set_target_properties(${PROJECT_NAME}-editor PROPERTIES
-        INSTALL_NAME_DIR "@executable_path"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG "../../${LIB_PATH}"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "../../${LIB_PATH}"
+    )
+
+    # Install Vorbis Dynamic Library
+    install(TARGETS ${PROJECT_NAME}-editor
+            LIBRARY DESTINATION ${LIB_PATH}
+            ARCHIVE DESTINATION ${LIB_PATH}
+            RUNTIME DESTINATION ${LIB_PATH}
     )
 endif()
-
-set_target_properties(${PROJECT_NAME}-editor PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY_DEBUG "../../${LIB_PATH}"
-    RUNTIME_OUTPUT_DIRECTORY_RELEASE "../../${LIB_PATH}"
-)
-
-# Install Vorbis Dynamic Library
-install(TARGETS ${PROJECT_NAME}-editor
-        LIBRARY DESTINATION ${LIB_PATH}
-        ARCHIVE DESTINATION ${LIB_PATH}
-        RUNTIME DESTINATION ${LIB_PATH}
-)
 
 # Static Library
 add_library(${PROJECT_NAME} STATIC ${vorbis_src_files})
@@ -86,39 +99,52 @@ install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION ${STATIC_PATH}
 )
 
-# VorbisFile Dynamic Library
-add_library(${PROJECT_NAME}file-editor SHARED "src/vorbisfile.c")
-target_include_directories(${PROJECT_NAME}file-editor PRIVATE "../libogg/src")
-target_compile_definitions(${PROJECT_NAME}file-editor PRIVATE LIBVORBIS_LIBRARY)
+if(desktop)
+    # VorbisFile Dynamic Library
+    add_library(${PROJECT_NAME}file-editor SHARED "src/vorbisfile.c")
+    target_include_directories(${PROJECT_NAME}file-editor PRIVATE "../libogg/src")
+    target_compile_definitions(${PROJECT_NAME}file-editor PRIVATE LIBVORBIS_LIBRARY)
 
-if(MSVC)
-    target_sources(${PROJECT_NAME}file-editor PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/vorbisfile.def #
+    if(MSVC)
+        target_sources(${PROJECT_NAME}file-editor PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/vorbisfile.def #
+        )
+    endif ()
+
+    target_link_libraries(${PROJECT_NAME}file-editor PRIVATE
+        ogg-editor
+        vorbis-editor
     )
-endif ()
 
-target_link_libraries(${PROJECT_NAME}file-editor PRIVATE
-    ogg-editor
-    vorbis-editor
-)
+    if (APPLE)
+        set_target_properties(${PROJECT_NAME}file-editor PROPERTIES
+            INSTALL_NAME_DIR "@executable_path"
+        )
+    endif()
 
-if (APPLE)
+    if(UNIX AND NOT APPLE)
+        set_target_properties(${PROJECT_NAME}file-editor PROPERTIES
+            INSTALL_RPATH "$ORIGIN/../lib"
+        )
+
+        # Solve build error using Clang on BSDs
+        if(NOT LINUX)
+            target_compile_options(${PROJECT_NAME}file-editor PRIVATE -fPIC)
+        endif()
+    endif()
+
     set_target_properties(${PROJECT_NAME}file-editor PROPERTIES
-        INSTALL_NAME_DIR "@executable_path"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG "../../${LIB_PATH}"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "../../${LIB_PATH}"
+    )
+
+    # Install Vorbis Dynamic Library
+    install(TARGETS ${PROJECT_NAME}file-editor
+            LIBRARY DESTINATION ${LIB_PATH}
+            ARCHIVE DESTINATION ${LIB_PATH}
+            RUNTIME DESTINATION ${LIB_PATH}
     )
 endif()
-
-set_target_properties(${PROJECT_NAME}file-editor PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY_DEBUG "../../${LIB_PATH}"
-    RUNTIME_OUTPUT_DIRECTORY_RELEASE "../../${LIB_PATH}"
-)
-
-# Install Vorbis Dynamic Library
-install(TARGETS ${PROJECT_NAME}file-editor
-        LIBRARY DESTINATION ${LIB_PATH}
-        ARCHIVE DESTINATION ${LIB_PATH}
-        RUNTIME DESTINATION ${LIB_PATH}
-)
 
 # VorbisFile Static Library
 add_library(${PROJECT_NAME}file STATIC "src/vorbisfile.c")

--- a/thirdparty/libvorbis/vorbis.qbs
+++ b/thirdparty/libvorbis/vorbis.qbs
@@ -52,6 +52,11 @@ Project {
         }
 
         Properties {
+            condition: qbs.targetOS.contains("linux")
+            cpp.rpaths: "$ORIGIN/../lib"
+        }
+
+        Properties {
             condition: qbs.targetOS.contains("darwin")
             cpp.sonamePrefix: "@executable_path"
         }
@@ -104,6 +109,11 @@ Project {
         Properties {
             condition: qbs.targetOS.contains("windows") && !qbs.toolchain.contains("gcc")
             cpp.linkerFlags: ["/DEF:" + path + "/src/vorbisfile.def"]
+        }
+
+        Properties {
+            condition: qbs.targetOS.contains("linux")
+            cpp.rpaths: "$ORIGIN/../lib"
         }
 
         Properties {

--- a/thirdparty/physfs/CMakeLists.txt
+++ b/thirdparty/physfs/CMakeLists.txt
@@ -54,9 +54,15 @@ if(desktop)
         target_compile_definitions(${PROJECT_NAME}-editor PRIVATE PHYSFS_DARWIN)
     endif()
 
-    # Solve build error using Clang on BSDs
-    if(UNIX AND NOT APPLE AND NOT LINUX)
-        target_compile_options(${PROJECT_NAME}-editor PRIVATE -fPIC)
+    if(UNIX AND NOT APPLE)
+        set_target_properties(${PROJECT_NAME}-editor PROPERTIES
+            INSTALL_RPATH "$ORIGIN/../lib"
+        )
+
+        # Solve build error using Clang on BSDs
+        if(NOT LINUX)
+            target_compile_options(${PROJECT_NAME}-editor PRIVATE -fPIC)
+        endif()
     endif()
 
     set_target_properties(${PROJECT_NAME}-editor PROPERTIES

--- a/thirdparty/physfs/physfs.qbs
+++ b/thirdparty/physfs/physfs.qbs
@@ -40,6 +40,11 @@ Project {
         }
 
         Properties {
+            condition: qbs.targetOS.contains("linux")
+            cpp.rpaths: "$ORIGIN/../lib"
+        }
+
+        Properties {
             condition: qbs.targetOS.contains("darwin")
             cpp.defines: outer.concat(["PHYSFS_DARWIN"])
             cpp.sonamePrefix: "@executable_path"


### PR DESCRIPTION
This PR should close these issues:

https://github.com/thunder-engine/thunder/issues/775

https://github.com/thunder-engine/thunder/issues/523

If anyone is having issues linking OpenAL on Linux using qbs, I've implemented find_package(OpenAL) in the media CMake file for both platforms as a fix. 

I'll let the build system run its tasks. If they finish successfully, I'll check to make sure the Linux libraries are linked correctly. If either fail, I'll quickly fix them and then try again like I have been. At least it's now getting this far:

```
 [PluginManager] Can't load plugin: /home/brad/git/thunder-build/install-root/sdk/2024.2/freebsd/x86/bin/uikit-editor.so
 [PluginManager] Can't load plugin: /home/brad/git/thunder-build/install-root/sdk/2024.2/freebsd/x86/bin/plugins/libmotiontools.so
 [PluginManager] Can't load plugin: /home/brad/git/thunder-build/install-root/sdk/2024.2/freebsd/x86/bin/plugins/libshadertools.so
 [PluginManager] Can't load plugin: /home/brad/git/thunder-build/install-root/sdk/2024.2/freebsd/x86/bin/plugins/libpipelinetools.so
 Converting: /home/brad/git/thunder-build/install-r
oot/sdk/2024.2/resources/editor/gizmos/postprocess.png
 Converting: /home/brad/git/thunder-build/install-root/sdk/2024.2/resources/editor/gizmos/soundsource.png
 Converting: /home/brad/git/thunder-build/install-root/sdk/2024.2/resources/editor/gizmos/pointlight.png
 Converting: /home/brad/git/thunder-build/install-root/sdk/2024.2/resources/editor/gizmos/camera.png
 Converting: /home/brad/git/thunder-build/install-root/sdk/2024.2/resources/engine/textures/invalid.png
 Converting: /home/brad/git/thunder-build/install-root/sdk/2024.2/resources/editor/gizmos/spotlight.png
 Converting: /home/brad/git/thunder-build/install-root/sdk/2024.2/resources/editor/gizmos/directlight.png
 Converting: /home/brad/git/thunder-build/install-root/sdk/2024.2/resources/engine/textures/ui.png
 Converting: /home/brad/git/thunder-build/install-root/sdk/2024.2/resources/engine/fonts/Roboto.ttf
 [ FileIO ] Can't open file .embedded/DefaultMesh.shader
fish: Job 1, './install-root/sdk/2024.2/freeb…' terminated by signal SIGSEGV (Address boundary error)
```

