### PR TITLE
Fix: Assimp StackAllocator Upstream Code Fix

### DIFF
--- a/modules/editor/timeline/CMakeLists.txt
+++ b/modules/editor/timeline/CMakeLists.txt
@@ -85,11 +85,6 @@ if (desktop)
         endif()
     endif()
 
-    # Solve build error using Clang on BSDs
-    if(UNIX AND NOT APPLE AND NOT LINUX)
-        target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
-    endif()
-
     target_include_directories(${PROJECT_NAME} PRIVATE ${${PROJECT_NAME}_incPaths} ${CMAKE_CURRENT_BINARY_DIR})
 
     set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/thirdparty/assimp/code/Common/StackAllocator.h
+++ b/thirdparty/assimp/code/Common/StackAllocator.h
@@ -88,6 +88,11 @@ private:
 
 } // namespace Assimp
 
+/// @brief Fixes an undefined reference error when linking in certain build environments.
+//         May throw warnings about needing stdc++17, but should compile without issues on modern compilers.
+inline const size_t Assimp::StackAllocator::g_maxBytesPerBlock;
+inline const size_t Assimp::StackAllocator::g_startBytesPerBlock;
+
 #include "StackAllocator.inl"
 
 #endif // include guard

--- a/thirdparty/assimp/code/Common/StackAllocator.inl
+++ b/thirdparty/assimp/code/Common/StackAllocator.inl
@@ -56,7 +56,7 @@ inline void *StackAllocator::Allocate(size_t byteSize) {
     {
         // double block size every time, up to maximum of g_maxBytesPerBlock.
         // Block size must be at least as large as byteSize, but we want to use this for small allocations anyway.
-        m_blockAllocationSize = std::max<std::size_t>(std::min<std::size_t>(m_blockAllocationSize * 2, (size_t)(64 * 1024 * 1024)), byteSize);
+        m_blockAllocationSize = std::max<std::size_t>(std::min<std::size_t>(m_blockAllocationSize * 2, g_maxBytesPerBlock), byteSize);
         uint8_t *data = new uint8_t[m_blockAllocationSize];
         m_storageBlocks.emplace_back(data);
         m_subIndex = byteSize;


### PR DESCRIPTION
My original StackAllocator fix has been accepted and merged upstream: https://github.com/assimp/assimp/pull/5650

I've updated CMake to work with it. I may still need to enforce qbs to use c++17 for the builds to pass. The latest master uses it for its CMake (see [here](https://github.com/assimp/assimp/blob/625528d02c17505e752ae63d8d23132782046807/CMakeLists.txt#L203)).