### PR TITLE
Fix: Hard path Fix #778

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ string(TIMESTAMP YEAR "%Y" UTC)
 
 # Set project properties
 set(COPYRIGHT_YEAR ${YEAR})
-set(RESOURCE_ROOT "../worldeditor/bin/")
+set(RESOURCE_ROOT "${CMAKE_SOURCE_DIR}/worldeditor/bin/")
 
 set(PREFIX "")
 set(LAUNCHER_PATH "launcher")


### PR DESCRIPTION
This may not fully fix the issue (need to test after work), but the original hard path would break installing resources if building with CMake out of source tree (how I build to keep from accidentally polluting my source tree and any repo I send code to); `../worldeditor/bin` wouldn’t always exist unless the developer created it themselves prior to building.