### PR TITLE
Workflow: Simple FreeBSD CMake Builder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ env:
   QTCREATOR_VERSION: 11.0.3
   VERSION: 2024.2
   THUNDER_RELEASE: ${{ startsWith(github.ref, 'refs/tags/2') }}
+  BSD_VERSION: 14.1
 
 jobs:
   version:
@@ -249,10 +250,52 @@ jobs:
         name: ThunderEngine-windows-x64.7z
         path: ThunderEngine-windows-x64.7z
     
+  freebsd:
+    name: FreeBSD
+    runs-on: ubuntu-latest
+    needs: version
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        repository: 'bedwardly-down/thunder-bsd'
+        path: 'thunder'
+        ref: 'fix-moc-cmake'
+
+    - name: Build Thunder
+      uses: vmactions/freebsd-vm@v1
+      with:
+        release: "${{ env.BSD_VERSION }}"
+        usesh: true
+        sync: rsync
+        prepare: |
+          pkg install -y git llvm17 libinotify openal-soft xorg 7-zip cmake ninja pkgconf ccache
+          pkg install -y qt5-widgets qt5-core qt5-gamepad qt5-gui qt5-svg qt5-xml qmake qt5 
+        run: |
+          mkdir -pv thunder-build
+          cd thunder-build
+          CC=clang17 CXX=clang++17 cmake ../thunder -G "Ninja"
+          ninja
+          ninja install
+          mkdir -pv release
+          mv -v install-root release
+          7z a -t7z ../ThunderEngine-freebsd-x64.7z release/install-root
+          cd ..
+          mv -v thunder /tmp
+          mv -v thunder-build /tmp
+
+    - name: Upload Thunder
+      uses: actions/upload-artifact@v2
+      with:
+          name: ThunderEngine-freebsd-x64.7z
+          path: ThunderEngine-freebsd-x64.7z
+
   github:
     name: Upload to GitHub releases
     runs-on: ubuntu-latest
-    needs: [version, linux, windows, android, ios, tvos]
+    needs: [version, linux, windows, android, ios, tvos, freebsd]
 
     if: github.repository == 'thunder-engine/thunder' && needs.version.outputs.release == 'true'
 
@@ -299,6 +342,12 @@ jobs:
         with:
           name: ThunderEngine-android.7z
 
+      - name: Download FreeBSD binaries
+        id: download-freebsd
+        uses: actions/download-artifact@v2
+        with:
+          name: ThunderEngine-freebsd-x64.7z
+
       - name: Upload Windows
         uses: actions/upload-release-asset@v1
         with:
@@ -337,4 +386,12 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ThunderEngine-android.7z
           asset_name: ThunderEngine-android.7z
+          asset_content_type: application/x-7z-compressed
+
+      - name: Upload FreeBSD
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ThunderEngine-freebsd-x64.7z
+          asset_name: ThunderEngine-freebsd-x64.7z
           asset_content_type: application/x-7z-compressed

--- a/modules/editor/grapheditor/CMakeLists.txt
+++ b/modules/editor/grapheditor/CMakeLists.txt
@@ -35,15 +35,10 @@ file(GLOB MOC_HEADERS
     "editor/graph/graphwidgets/*.h"
 )
 
-set(RESOURCES
-    grapheditor.qrc
-)
-
-QT5_ADD_RESOURCES(RES_SOURCES ${RESOURCES})
 QT5_WRAP_CPP(MOC_SRCS ${MOC_HEADERS})
 
 if (desktop)
-    add_library(${PROJECT_NAME}-editor SHARED ${${PROJECT_NAME}_srcFiles} ${MOC_SRCS} ${RES_SOURCES})
+    add_library(${PROJECT_NAME}-editor SHARED ${${PROJECT_NAME}_srcFiles} ${MOC_SRCS})
 
     target_link_libraries(${PROJECT_NAME}-editor PRIVATE
         next-editor

--- a/modules/uikit/CMakeLists.txt
+++ b/modules/uikit/CMakeLists.txt
@@ -46,9 +46,9 @@ file(GLOB ${PROJECT_NAME}_ui
 )
 
 file(GLOB MOC_HEADERS
-    "includes/converters/*.h"
     "includes/editor/*.h"
     "includes/editor/tools/*.h"
+    "includes/converters/*.h"
 )
 
 set( RESOURCES


### PR DESCRIPTION
This just integrates the FreeBSD cmake build directly into the build tool chain with nothing fancy or special added to it. Relies on  https://github.com/thunder-engine/thunder/pull/795 and will replace https://github.com/thunder-engine/thunder/pull/793 . When the previous PR gets merged, this will need minimum changes outside of feedback to be fully ready.