### PR TITLE
CI: Update iOS and tvOS runners to Build Properly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,7 @@ jobs:
 # macos-latest is currently broken for the build system. This single comment should show the issue in effect.
   ios:
     name: iOS
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: version
 
     env:
@@ -181,7 +181,7 @@ jobs:
     
   tvos:
     name: tvOS
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: version
 
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,7 @@ jobs:
         name: ThunderEngine-android.7z
         path: ThunderEngine-android.7z
 
+# macos-latest is currently broken for the build system. This single comment should show the issue in effect.
   ios:
     name: iOS
     runs-on: macos-latest


### PR DESCRIPTION
The fist commit was just to show the breakage with a commit that doesn't affect anything. The second is the current fix. Not sure why but Macos-14 (macos-latest) is currently not using the build tools and dependencies correctly